### PR TITLE
Ensure .eval sends messages compliant with discord limits

### DIFF
--- a/plugins/eval.py
+++ b/plugins/eval.py
@@ -94,14 +94,12 @@ async def run_code(msg, args):
     message_outputs_chunked = chunk_concat(message_outputs, 2000) 
 
     enumeration_readable = enumerate(outputs, start = 1) 
-    file_outputs = [m for m in enumeration_readable if not short_heuristic(m[1])]
+    file_info = [m for m in enumeration_readable if not short_heuristic(m[1])] 
+    file_outputs = [make_file_output(*info) for info in file_info]
     file_outputs_chunked = chunk(file_outputs, 10) 
 
     output_messages = itertools.zip_longest(message_outputs_chunked, file_outputs_chunked)
     
-    for text, file_info in output_messages:
-        file_output = None
-        if file_info: 
-            file_output = [make_file_output(*args) for args in file_info]
+    for text, file_output in output_messages:
         await msg.channel.send(text, files = file_output)
 

--- a/plugins/eval.py
+++ b/plugins/eval.py
@@ -69,8 +69,7 @@ async def run_code(msg, args):
         inhabited = False 
         for text in l:
             inhabited = True 
-            new_len = len(current_value + text)
-            if new_len > n: 
+            if len(current_value + text) > n: 
                 yield current_value 
                 current_value = "" 
             current_value = current_value + text 
@@ -86,9 +85,7 @@ async def run_code(msg, args):
     
     def make_file_output(idx, fp): 
         fp.seek(0)
-        discord_filename = "output{:d}.txt".format(idx)
-        discord_file = discord.File(fp, filename = discord_filename)
-        return discord_file
+        return discord.File(fp, filename = "output{:d}.txt".format(idx))
 
     message_outputs = chunk_concat((format_block(m) for m in outputs if short_heuristic(m)), 2000) 
     file_outputs = chunk((make_file_output(*m) for m in enumerate(outputs, start = 1) if not short_heuristic(m[1])), 10)  

--- a/plugins/eval.py
+++ b/plugins/eval.py
@@ -86,16 +86,9 @@ async def run_code(msg, args):
         discord_file = discord.File(fp, filename = discord_filename)
         return discord_file
 
-    message_outputs = [format_block(m) for m in outputs if short_heuristic(m)] 
-    message_outputs_chunked = chunk_concat(message_outputs, 2000) 
-
-    enumeration_readable = enumerate(outputs, start = 1) 
-    file_info = [m for m in enumeration_readable if not short_heuristic(m[1])] 
-    file_outputs = [make_file_output(*info) for info in file_info]
-    file_outputs_chunked = chunk(file_outputs, 10) 
-
-    output_messages = itertools.zip_longest(message_outputs_chunked, file_outputs_chunked)
+    message_outputs = chunk_concat([format_block(m) for m in outputs if short_heuristic(m)], 2000) 
+    file_outputs = chunk([make_file_output(*m) for m in enumerate(outputs, start = 1) if not short_heuristic(m[1])], 10)  
     
-    for text, file_output in output_messages:
+    for text, file_output in itertools.zip_longest(message_outputs, file_outputs):
         await msg.channel.send(text, files = file_output)
 

--- a/plugins/eval.py
+++ b/plugins/eval.py
@@ -78,11 +78,7 @@ async def run_code(msg, args):
         return util.discord.format("{!b:py}", text) if len(text) else "\u2705"
     
     def short_heuristic(fp): 
-        initial_pos = fp.tell() 
-        fp.seek(0, os.SEEK_END) 
-        fp_len = fp.tell() 
-        fp.seek(initial_pos) 
-        return fp_len <= 2000 and len(format_block(fp)) <= 2000
+        return len(format_block(fp)) <= 2000
     
     def make_file_output(idx, fp): 
         fp.seek(0)


### PR DESCRIPTION
This is a solution to #17, but also ensures that multiple outputted codeblocks don't exceed discord's size limits for messages: this is done by sending multiple messages. 

Outputs that can be sent as codeblocks are greedily sent, with the first message containing as many consecutive codeblocks as possible: these codeblocks are sent in order. This process continues for subsequent messages.  

Outputs that can't be sent as codeblocks are attached to these same messages as files, and are named with the position they appeared in the evaluation queue: this process is also greedy, with a limit of 10 files per message. 