### PR TITLE
roles_review QOL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ A review system for role requests. When a role is requested via `roles_dialog`, 
 
 Commands:
 - `review_reset <user> <role>` -- when a user's application is denied, they are not allowed to submit another until this command is invoked on them.
-- `review_queue` -- show a list of links to unresolved applications.
+- `review_queue <any|mine>` -- show a list of links to unresolved applications. Optional parameter `whose` determines whether to list *all* unresolved applications (`any`) or only unresolved applications that the calling user has not voted on (`mine`). Defaults to `whose = "mine"`.
 
 Config:
 - ``config plugins.roles_review <role> `{...}` `` -- attempting to self-assign the role will instead make the user go through the application process. The keys in the object are as followws:

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ A review system for role requests. When a role is requested via `roles_dialog`, 
 
 Commands:
 - `review_reset <user> <role>` -- when a user's application is denied, they are not allowed to submit another until this command is invoked on them.
-- `review_queue <any|mine>` -- show a list of links to unresolved applications. Optional parameter `whose` determines whether to list *all* unresolved applications (`any`) or only unresolved applications that the calling user has not voted on (`mine`). Defaults to `whose = "mine"`.
+- `review_queue [any|mine]` -- show a list of links to unresolved applications. The argument `any` will list all unresolved applications, whereas `mine` will list only applications that the user hasn't yet voted on. Without an argument, defaults to `mine`.
 
 Config:
 - ``config plugins.roles_review <role> `{...}` `` -- attempting to self-assign the role will instead make the user go through the application process. The keys in the object are as followws:

--- a/plugins/roles_review.py
+++ b/plugins/roles_review.py
@@ -383,7 +383,9 @@ class RolesReviewCog(Cog):
             if whose == "any":
                 stmt = select(Application).where(Application.decision == None).order_by(Application.listing_id)
             else:
-                stmt = (select(Application).outerjoin(Vote, Vote.application_id.and_(Vote.voter_id == ctx.author.id))
+                stmt = (select(Application)
+                        .outerjoin(Vote, (Application.id == Vote.application_id) & (Vote.voter_id == ctx.author.id))
+                        .where(Vote.application_id == None)
                         .order_by(Application.listing_id))
 
             apps = (await session.execute(stmt)).scalars()
@@ -392,7 +394,7 @@ class RolesReviewCog(Cog):
                 yield PlainItem("Applications:\n")
                 for app in apps:
                     if app.voting_id is None:
-                        break
+                        continue
                     if conf[app.role_id] is None:
                         yield PlainItem("{} (?)".format(app.listing_id))
                         continue

--- a/plugins/roles_review.py
+++ b/plugins/roles_review.py
@@ -383,7 +383,8 @@ class RolesReviewCog(Cog):
             if whose == "any":
                 stmt = select(Application).where(Application.decision == None).order_by(Application.listing_id)
             else:
-                stmt = select(Application).outerjoin(Vote, Vote.application_id.and_(Vote.voter_id == ctx.author.id))
+                stmt = (select(Application).outerjoin(Vote, Vote.application_id.and_(Vote.voter_id == ctx.author.id))
+                        .order_by(Application.listing_id))
 
             apps = (await session.execute(stmt)).scalars()
 


### PR DESCRIPTION
- `.review_queue` now lists links to the vote message in each application thread rather than the listing message in the review channel.
- `.review_queue` now defaults to showing only applications that the calling user has *not* voted on.
- previous behaviour can be invoked via `.review_queue any`.
- bot sends a message in the application thread containing the raw user ID to make copy-pasting the user ID easier on mobile.