### PR TITLE
Ping @Helpers through the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Commands:
 
 Config:
 - ``config plugins.tickets guild <guild id>`` -- guild for which tickets are being managed.
-- ``config plugins.tickets tracked_roles `[<channel id>, ...]` `` -- list of roles assigning which counts as administrative action (e.g. a muted role).
+- ``config plugins.tickets tracked_roles `[<role id>, ...]` `` -- list of roles assigning which counts as administrative action (e.g. a muted role).
 - ``config plugins.tickets ticket_list <channel id>`` -- channel where the log of tickets should be displayed.
 - ``config plugins.tickets prompt_interval <interval>`` -- if a moderator doesn't reply to a prompt for a comment, after how long (in seconds) should they be reminded?
 - ``config plugins.tickets audit_log_precision <float>`` -- in large guilds the audit log may lag behind, causing the bot to only realize much later that an action has had been taken. This is a delay (in seconds) to compensate.
@@ -368,7 +368,7 @@ Now you can run the bot by executing `main.py`. You can continue the configurati
 .load eval
 .autoload add db_manager
 .autoload add discord_log
-.audoload add eval
+.autoload add eval
 ```
 The `python -m util.db.kv` shell command is analogous to the `.config` Discord command.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Config:
 - ``config plugins.clopen used_category <category id>`` -- where "occupied" channels are placed.
 - ``config plugins.clopen hidden_category <category id>`` -- where "hidden" channels are placed.
 - ``config plugins.clopen owner_timeout <timeout>`` -- how long (in seconds, initially) since the last message by the owner before the owner is prompted about closure, and how long until the channel is automatically closed if there was no response.
+- ``config plugins.clopen ping_timeout <timeout>`` -- how long (in seconds) until a helpee can use the ping helpers button.
 - ``config plugins.clopen timeout <timeout>`` -- how long (in seconds) since the last message by anyone else before the owner is prompted about closure.
 - ``config plugins.clopen min_avail <number>`` -- how many channels minimum should be "available". If not enough channels are available, channels may be unhidden, or new channels may be created.
 - ``config plugins.clopen max_avail <number>`` -- how many channels maximum should be "available". If too many channels are available, some may be hidden.

--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ Commands:
 - `review_queue [any|mine]` -- show a list of links to unresolved applications. The argument `any` will list all unresolved applications, whereas `mine` will list only applications that the user hasn't yet voted on. Without an argument, defaults to `mine`.
 
 Config:
-- ``config plugins.roles_review <role> `{...}` `` -- attempting to self-assign the role will instead make the user go through the application process. The keys in the object are as followws:
+- ``config plugins.roles_review <role> `{...}` `` -- attempting to self-assign the role will instead make the user go through the application process. The keys in the object are as follows:
     - `"prompt": ["<question>[\n<placeholder>]", ...]` -- list of questions to ask an applicant.
     - `"review_channel": <channel id>` -- channel where the applications will be posted and voted on.
     - `"upvote_limit": <number>` -- how many upvotes are needed to accept an application.
-    - `"downvote_limit": <number>` -- how many downvotes are needed to accept an application.
+    - `"downvote_limit": <number>` -- how many downvotes are needed to reject an application.
     - `"pending_role": <role id>` -- (optional) role given to the applying user while the application is pending.
     - `"denied_role": <role id>` -- (optional) role given to the applying user if their application is denied.
 

--- a/plugins/clopen.py
+++ b/plugins/clopen.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import defaultdict
 import logging
 from time import time
-from typing import (TYPE_CHECKING, Awaitable, Dict, Iterable, List, Literal, Optional, Protocol, Tuple, Union, cast,
+from typing import (TYPE_CHECKING, Awaitable, Callable, Any, Dict, Iterable, List, Literal, Optional, Protocol, Tuple, Union, cast,
     overload)
 
 import discord
@@ -107,8 +107,7 @@ class ClopenConf(Awaitable[None], Protocol):
     @overload
     def __setitem__(self, k: Tuple[int, Literal["expiry"]], v: Optional[float]) -> None: ...
     @overload
-    def __setitem__(self, k: Tuple[int, Literal["pinged"]], v: bool) -> False: ...
-
+    def __setitem__(self, k: Tuple[int, Literal["pinged"]], v: bool) -> None: ...
 
 
 conf: ClopenConf
@@ -377,6 +376,7 @@ async def extend(id: int) -> None:
     await conf
     scheduler_task.run_coalesced(0)
 
+
 async def make_pending(id: int) -> None:
     logger.debug("Prompting {} for closure".format(id))
     assert isinstance(channel := client.get_channel(id), TextChannel)
@@ -385,15 +385,18 @@ async def make_pending(id: int) -> None:
     extension = conf[id, "extension"]
     if extension is None:
         extension = 1
+
     conf[id, "expiry"] = time() + conf.owner_timeout * extension
 
-    if [conf[id, "ping_id"]] is not None:
-        await PartialMessage(channel=channel, id=conf[channel.id, "prompt_id"]).edit(view=None)
+    if conf[id, "prompt_id"] is not None:
+        await PartialMessage(channel=channel, id=conf[id, "prompt_id"] or 0).edit(view=None)
+
     prompt = await channel.send(prompt_message(owner), view=PromptView(channel, owner))
     conf[id, "prompt_id"] = prompt.id
     conf[id, "state"] = "pending"
     await conf
     scheduler_task.run_coalesced(0)
+
 
 async def reopen(id: int) -> None:
     logger.debug("Reopening {}".format(id))
@@ -546,8 +549,8 @@ class PostTitleModal(Modal):
             return
         await interaction.response.send_message("\u2705", ephemeral=True, delete_after=60)
 
-def owner_only(func):
-    async def wrapper(self, interaction: Interaction, *args, **kwargs):
+def owner_only(func: Callable[..., Awaitable[None]]):
+    async def wrapper(self: "PromptView", interaction: Interaction, *args: Any, **kwargs: Any) -> None:
         if interaction.user.id != self.owner:
             await interaction.response.send_message("This isn't yours.", ephemeral=True,
                 delete_after=60)
@@ -556,7 +559,7 @@ def owner_only(func):
     return wrapper
 
 class PromptView(View):
-    def __init__(self, channel: TextChannel, owner: User) -> None:
+    def __init__(self, channel: TextChannel, owner: int) -> None:
         super().__init__(timeout=None)
         self.channel = channel
         self.owner = owner
@@ -569,7 +572,7 @@ class PromptView(View):
         if not conf[self.channel.id, "pinged"]:
             self.add_item(self.ping_button)
 
-    def create_button(self, label, style, callback):
+    def create_button(self, label: str, style: ButtonStyle, callback: Callable[..., Any]) -> Any:
         button = Button(label=label, style=style)
         button.callback = callback
         return button
@@ -595,15 +598,19 @@ class PromptView(View):
             await interaction.response.defer()
         else:
             self.clear_items()
-            ping_button = self.create_button("Ping Helpers", ButtonStyle.danger,
-                        lambda interaction: self.ping_callback(interaction, True))
+            ping_button = self.create_button("Ping Helpers", ButtonStyle.danger, self.ping_button_callback)
             self.add_item(ping_button)
             await extend(self.channel.id)
-            await interaction.message.edit(view=self)
+            if interaction.message is not None:
+                await interaction.message.edit(view=self)
             await interaction.response.defer()
 
     @owner_only
-    async def ping_callback(self, interaction, clicked=False) -> None:
+    async def ping_button_callback(self, interaction: Interaction) -> None:
+        await self.ping_callback(interaction, True)
+
+    @owner_only
+    async def ping_callback(self, interaction: Any, clicked: bool = False) -> None:
         if conf[self.channel.id, "state"] == "closed":
             await interaction.response.defer()
             return
@@ -618,21 +625,24 @@ class PromptView(View):
         allowed_mentions = discord.AllowedMentions(roles = True)
         conf[self.channel.id, "last_prompt"] = interaction.message.id # slightly different from prompt_id
         ping_tasks[interaction.message.id] = asyncio.create_task(self.timeout_ping(ping_time, interaction))
-        await interaction.message.edit(content=f"You can ping again <t:{two_hours_later}:R>", view=None)
+        if interaction.message is not None:
+            await interaction.message.edit(content=f"You can ping again <t:{two_hours_later}:R>", view=None)
         await interaction.channel.send(f"<@&{helpers}>", allowed_mentions=allowed_mentions)
 
-    async def timeout_ping(self, delay: int, interaction):
+    async def timeout_ping(self, delay: int, interaction: Any) -> None:
         await asyncio.sleep(delay)
         conf[self.channel.id, "pinged"] = False
         self.ping_button.disabled = False
         self.clear_items()
-        button = self.create_button("Ping Helpers", ButtonStyle.danger,
-                lambda interaction: self.ping_callback(interaction, True))
+
+        button = self.create_button("Ping Helpers", ButtonStyle.danger, self.ping_button_callback)
         self.add_item(button)
 
         second_prompt = await interaction.channel.send("You can ping again now", view=self)
         conf[self.channel.id, "prompt_id"] = second_prompt.id
-        await interaction.message.delete()
+        if interaction.message is not None:
+            await interaction.message.delete()
+
 
 async def manage_title(interaction: Interaction, thread_id: int) -> None:
     try:

--- a/plugins/clopen.py
+++ b/plugins/clopen.py
@@ -590,11 +590,13 @@ class PromptView(View):
 
         if conf[self.channel.id, "pinged"]:
             await extend(self.channel.id)
-            await self.channel.send("Please be patient while helpers attend to your channel", ephemeral=True)
+            await interaction.response.send_message("Please be patient while helpers attend to your channel.",
+                    ephemeral=True)
             await interaction.response.defer()
         else:
             self.clear_items()
-            ping_button = self.create_button("Ping Helpers", ButtonStyle.danger, lambda interaction: self.ping_callback(interaction, True))
+            ping_button = self.create_button("Ping Helpers", ButtonStyle.danger,
+                        lambda interaction: self.ping_callback(interaction, True))
             self.add_item(ping_button)
             await extend(self.channel.id)
             await interaction.message.edit(view=self)
@@ -624,7 +626,8 @@ class PromptView(View):
         conf[self.channel.id, "pinged"] = False
         self.ping_button.disabled = False
         self.clear_items()
-        button = self.create_button("Ping Helpers", ButtonStyle.danger, lambda interaction: self.ping_callback(interaction, True))
+        button = self.create_button("Ping Helpers", ButtonStyle.danger,
+                lambda interaction: self.ping_callback(interaction, True))
         self.add_item(button)
 
         second_prompt = await interaction.channel.send("You can ping again now", view=self)

--- a/plugins/clopen.py
+++ b/plugins/clopen.py
@@ -29,7 +29,7 @@ from util.frozen_list import FrozenList
 
 
 ping_tasks = {}
-helpers = 1184614977856872468 # considering moving to conf
+helpers = 286206848099549185 # considering moving to conf
 def available_embed() -> Embed:
     checkmark_url = "https://cdn.discordapp.com/emojis/901284681633370153.png?size=256"
     help_chan = 488120190538743810
@@ -586,11 +586,6 @@ class PromptView(View):
     async def no_callback(self, interaction: Interaction) -> None:
         if conf[self.channel.id, "state"] != "pending":
             await interaction.response.defer()
-            return
-
-        if interaction.user.id != self.owner:
-            await interaction.response.send_message("This isn't yours", ephemeral=True,
-                delete_after=60)
             return
 
         if conf[self.channel.id, "pinged"]:


### PR DESCRIPTION
Full Meta Proposal: https://discord.com/channels/268882317391429632/1181816468254507038
Summary:
To prevent the misuse of  @Helpers ping, only the bot should be allowed to ping in a timeout based manner.

TODO: `config plugins.clopen ping_timeout 7200`