### PR TITLE
Add mobile copy-able user snowflakes & mentions in modmail

### DIFF
--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -59,7 +59,8 @@ class ModmailMessage:
 
     if TYPE_CHECKING:
 
-        def __init__(self, *, dm_channel_id: int, dm_message_id: int, staff_message_id: int) -> None: ...
+        def __init__(self, *, dm_channel_id: int, dm_message_id: int, staff_message_id: int) -> None:
+            ...
 
 
 @registry.mapped
@@ -73,7 +74,8 @@ class ModmailThread:
 
     if TYPE_CHECKING:
 
-        def __init__(self, *, user_id: int, thread_first_message_id: int, last_used: datetime) -> None: ...
+        def __init__(self, *, user_id: int, thread_first_message_id: int, last_used: datetime) -> None:
+            ...
 
 
 @registry.mapped
@@ -91,7 +93,8 @@ class GuildConfig:
 
         def __init__(
             self, *, guild_id: int, token: str, channel_id: int, role_id: int, thread_expiry: timedelta
-        ) -> None: ...
+        ) -> None:
+            ...
 
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -194,8 +194,6 @@ class ModMailClient(Client):
             if thread_id is not None:
                 reference = MessageReference(message_id=thread_id, channel_id=channel.id, fail_if_not_exists=False)
 
-            copy_first = None
-
             if reference is not None:
                 header_copy = await retry(
                     lambda: channel.send(embed=header, allowed_mentions=mentions, reference=reference), attempts=10
@@ -209,8 +207,8 @@ class ModMailClient(Client):
                 copy = await retry(lambda: channel.send(content, allowed_mentions=mentions), attempts=10)
                 await add_modmail(msg, copy)
 
-            if thread_id is None and copy_first is not None:
-                await retry(lambda: create_thread(msg.author.id, copy_first.id), attempts=10)
+            if thread_id is None:
+                await retry(lambda: create_thread(msg.author.id, header_copy.id), attempts=10)
 
             await msg.add_reaction("\u2709")
 

--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -58,8 +58,8 @@ class ModmailMessage:
     staff_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     if TYPE_CHECKING:
-        def __init__(self, *, dm_channel_id: int, dm_message_id: int, staff_message_id: int) -> None:
-            ...
+
+        def __init__(self, *, dm_channel_id: int, dm_message_id: int, staff_message_id: int) -> None: ...
 
 
 @registry.mapped
@@ -72,8 +72,8 @@ class ModmailThread:
     last_used: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
 
     if TYPE_CHECKING:
-        def __init__(self, *, user_id: int, thread_first_message_id: int, last_used: datetime) -> None:
-            ...
+
+        def __init__(self, *, user_id: int, thread_first_message_id: int, last_used: datetime) -> None: ...
 
 
 @registry.mapped
@@ -88,10 +88,10 @@ class GuildConfig:
     thread_expiry: Mapped[timedelta] = mapped_column(INTERVAL, nullable=False)
 
     if TYPE_CHECKING:
+
         def __init__(
-                self, *, guild_id: int, token: str, channel_id: int, role_id: int, thread_expiry: timedelta
-        ) -> None:
-            ...
+            self, *, guild_id: int, token: str, channel_id: int, role_id: int, thread_expiry: timedelta
+        ) -> None: ...
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -169,14 +169,13 @@ class ModMailClient(Client):
                 PlainItem(msg.content),
             ]
 
-            header = (discord.Embed(
-                title=format("Modmail from {}#{}", msg.author.name, msg.author.discriminator),
-                timestamp=msg.created_at
-            ).add_field(
-                name="From",
-                value=format("{!m}", msg.author)).add_field(
-                name="ID",
-                value=msg.author.id)
+            header = (
+                discord.Embed(
+                    title=format("Modmail from {}#{}", msg.author.name, msg.author.discriminator),
+                    timestamp=msg.created_at,
+                )
+                .add_field(name="From", value=format("{!m}", msg.author))
+                .add_field(name="ID", value=msg.author.id)
             )
 
             footer = "".join("\n**Attachment:** {} {}".format(att.filename, att.url) for att in msg.attachments)
@@ -315,11 +314,11 @@ async def config(ctx: GuildContext, server: PartialGuildConverter) -> None:
 
 @config.command("new")
 async def config_new(
-        ctx: GuildContext,
-        token: str,
-        channel: PartialChannelConverter,
-        role: PartialRoleConverter,
-        thread_expiry: DurationConverter,
+    ctx: GuildContext,
+    token: str,
+    channel: PartialChannelConverter,
+    role: PartialRoleConverter,
+    thread_expiry: DurationConverter,
 ) -> None:
     async with sessionmaker() as session:
         session.add(

--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -196,9 +196,12 @@ class ModMailClient(Client):
 
             copy_first = None
 
-            header_copy = await retry(
-                lambda: channel.send(embed=header, allowed_mentions=mentions, reference=reference), attempts=10
-            )
+            if reference is not None:
+                header_copy = await retry(
+                    lambda: channel.send(embed=header, allowed_mentions=mentions, reference=reference), attempts=10
+                )
+            else:
+                header_copy = await retry(lambda: channel.send(embed=header, allowed_mentions=mentions), attempts=10)
 
             await add_modmail(msg, header_copy)
 

--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -44,6 +44,7 @@ from util.discord import (
     retry,
 )
 
+
 registry = sqlalchemy.orm.registry()
 sessionmaker = async_sessionmaker(util.db.engine, expire_on_commit=False)
 

--- a/plugins/modmail.py
+++ b/plugins/modmail.py
@@ -207,7 +207,7 @@ class ModMailClient(Client):
                 copy = await retry(lambda: channel.send(content, allowed_mentions=mentions), attempts=10)
                 await add_modmail(msg, copy)
 
-            if thread_id is None:
+            if thread_id is None and header_copy is not None:
                 await retry(lambda: create_thread(msg.author.id, header_copy.id), attempts=10)
 
             await msg.add_reaction("\u2709")


### PR DESCRIPTION
Previous behaviour did not allow mobile users to copy IDs from modmail easily. This adds an embed header which allows for copyability of the user's snowflake ID, and easier clicking of the mention. The change also means some simplification to the logic, as we no longer need to ensure we only reply once in the chunk_messages loop.