### PR TITLE
Added copyable userid to tickets

### DIFF
--- a/plugins/tickets.py
+++ b/plugins/tickets.py
@@ -479,6 +479,7 @@ class Ticket:
             timestamp=self.created_at,
             color=color,
         )
+        embed.add_field(name="User", value=self.targetid)
         embed.add_field(name="Moderator", value=format("{!m}", self.modid))
 
         if self.can_revert:


### PR DESCRIPTION
This creates a new embed field for User ID to all tickets, copy-able on mobile upon long press.