### PR TITLE
feat: Added 'Max Cap Timeout' for help channels

### DIFF
--- a/migrations/plugins.clopen-b25ab226ad95b4f90af72b7b29ec81ed6c6be5fa-4f94377eea1aacbc54e8179ca19edc966343fb15.sql
+++ b/migrations/plugins.clopen-b25ab226ad95b4f90af72b7b29ec81ed6c6be5fa-4f94377eea1aacbc54e8179ca19edc966343fb15.sql
@@ -1,0 +1,4 @@
+ALTER TABLE clopen.channels ADD COLUMN max_expiry TIMESTAMP;
+ALTER TABLE clopen.guilds
+ADD COLUMN timeout_cap INTERVAL NOT NULL
+DEFAULT INTERVAL '3 DAY';


### PR DESCRIPTION
Added a feature where a channel cannot stay open past a specified amount of time. The default value for cap is 3 days, but may be changed by configuring clopen. The command for configuration is:
`.config clopen <server id> timeout_cap [duration]`

This is tested locally with different amount of times ranging from a few minutes to an hour. I did not test for larger values since I was impatient. But it should still work.

More specifications:
Upon closing, a reason for closing will be given: "Channel closed due to maximum timeout reached!". The user is not, however, pinged as this is an embedded message. When closed, the channel will be archived (moved to hidden help channel category in the server).
Preview of closing notice:
![image](https://github.com/discord-math/bot/assets/144905277/3da7938c-1957-4ad3-8d4f-e423137e5144)