### PR TITLE
Add animals plugin, with cats and dogs command

### DIFF
--- a/migrations/plugins.animals-037e8d94bf0df85816f7fb3f37f34267400bab98-219174adad82bc86607c7ed6a5a1fde54f8bd3dc.sql
+++ b/migrations/plugins.animals-037e8d94bf0df85816f7fb3f37f34267400bab98-219174adad82bc86607c7ed6a5a1fde54f8bd3dc.sql
@@ -1,0 +1,9 @@
+create schema if not exists animals;
+create table if not exists animals.config (
+    id integer primary key,
+    cat_api_key text not null,
+    dog_api_key text not null
+);
+insert into animals.config (id, cat_api_key, dog_api_key)
+    values (0, '', '')
+    on conflict (id) do nothing;


### PR DESCRIPTION
No database changes. Someone will need to generate an API key for the cats and dogs APIs. Adds commands `.cat` and `.dog`, as well as `.config animals`.